### PR TITLE
Fix bug when contents jumps

### DIFF
--- a/litfx-controls/src/main/java/lit/litfx/controls/covalent/PathPane.java
+++ b/litfx-controls/src/main/java/lit/litfx/controls/covalent/PathPane.java
@@ -75,19 +75,19 @@ public class PathPane extends AnchorPane {
         outerFrame = createFramePath(this);
         outerFrame.getStyleClass().add("outer-path-frame");
 
-        scene.setOnMouseMoved(me -> {
-            // update segment listener (s0 s2, s2, none...)
-            // when segment listener's invalidation occurs fire cursor to change.
-            logLineSegment(me.getSceneX(), me.getSceneY());
-            outerFrame.toBack();
-//            System.out.println("scene mouse moved");
-        });
-
-        // reset cursor
-        scene.setOnMouseExited( mouseEvent -> {
-            segmentSelected.set(-1);
-            System.out.println("mouse exited group");
-        });
+//        scene.setOnMouseMoved(me -> {
+//            // update segment listener (s0 s2, s2, none...)
+//            // when segment listener's invalidation occurs fire cursor to change.
+//            logLineSegment(me.getSceneX(), me.getSceneY());
+//            outerFrame.toBack();
+////            System.out.println("scene mouse moved");
+//        });
+//
+//        // reset cursor
+//        scene.setOnMouseExited( mouseEvent -> {
+//            segmentSelected.set(-1);
+//            System.out.println("mouse exited group");
+//        });
 
         // createWindowButtons this is the title area and three buttons on top left.
         windowButtons = createWindowButtons(this);
@@ -122,8 +122,8 @@ public class PathPane extends AnchorPane {
         //Disable interactions with the content while minimized.
         contentPane.mouseTransparentProperty().bind(minimizedProperty);
         
-        getChildren().addAll(windowButtons, mainTitleArea,
-            leftAccent, leftTab, outerFrame, mainContentBorderFrame);
+        getChildren().addAll(outerFrame, windowButtons, mainTitleArea,
+            leftAccent, leftTab,  mainContentBorderFrame);
         enterScene = createEnterAnimation(
                 this.contentPane,
                 windowButtons,
@@ -194,6 +194,7 @@ public class PathPane extends AnchorPane {
             (CovalentPaneEvent t) -> {
                 previousLocation = new Point2D(getTranslateX(),getTranslateY());
             });
+
 
         wireListeners();
     }
@@ -579,73 +580,75 @@ public class PathPane extends AnchorPane {
     }
 
     private void wireListeners() {
-        resizePaneTracker = new ResizePaneTracker(contentPane);
 
-        resizePaneTracker.setOnMousePressed((mouseEvent, wt) -> {
-            // store anchor x,y of the stage
-            wt.anchorStageXYCoordValue.set(new Point2D(getTranslateX(), getTranslateY()));
-
-            // TODO Revisit code b/c this might be doing the same thing as line above.
-            wt.paneXCoordValue.set(getTranslateX());
-            wt.paneYCoordValue.set(getTranslateY());
-
-            // anchor of the mouse screen x,y position.
-            wt.anchorCoordValue.set(new Point2D(mouseEvent.getScreenX(), mouseEvent.getScreenY()));
-
-            // current width and height
-            wt.anchorWidthSizeValue.set(contentPane.getWidth());
-            wt.anchorHeightSizeValue.set(contentPane.getHeight());
-            System.out.println("press mouseX = " + mouseEvent.getX() + " translateX = " + getTranslateX());
-
-            // current resize direction
-            wt.currentResizeDirection.set(getCurrentResizeDirection());
-
-            // current line segment
-            wt.currentSegmentIndex.set(segmentSelected.get());
-        });
-
-        resizePaneTracker.setOnMouseDragged((mouseEvent, wt) -> {
-
+// // Rework the resize pane tracker work...
+//        resizePaneTracker = new ResizePaneTracker(contentPane);
+//
+//        resizePaneTracker.setOnMousePressed((mouseEvent, wt) -> {
+//            // store anchor x,y of the stage
+//            wt.anchorStageXYCoordValue.set(new Point2D(getTranslateX(), getTranslateY()));
+//
+//            // TODO Revisit code b/c this might be doing the same thing as line above.
+//            wt.paneXCoordValue.set(getTranslateX());
+//            wt.paneYCoordValue.set(getTranslateY());
+//
+//            // anchor of the mouse screen x,y position.
+//            wt.anchorCoordValue.set(new Point2D(mouseEvent.getScreenX(), mouseEvent.getScreenY()));
+//
+//            // current width and height
+//            wt.anchorWidthSizeValue.set(contentPane.getWidth());
+//            wt.anchorHeightSizeValue.set(contentPane.getHeight());
+//            System.out.println("press mouseX = " + mouseEvent.getX() + " translateX = " + getTranslateX());
+//
+//            // current resize direction
+//            wt.currentResizeDirection.set(getCurrentResizeDirection());
+//
+//            // current line segment
+//            wt.currentSegmentIndex.set(segmentSelected.get());
+//        });
+//
 //        resizePaneTracker.setOnMouseDragged((mouseEvent, wt) -> {
-            RESIZE_DIRECTION direction = wt.currentResizeDirection.get();
-
-            switch (direction) {
-                case NW:
-                    // TODO Northwest or Upper Left accuracy
-                    resizeNorth(mouseEvent, wt);
-                    resizeWest(mouseEvent, wt);
-                    break;
-                case N:
-                    resizeNorth(mouseEvent, wt);
-                    break;
-                case NE:
-                    //TODO Northeast Upper right corner accuracy
-                    resizeNorth(mouseEvent, wt);
-                    resizeEast(mouseEvent, wt);
-                    break;
-                case E:
-                    resizeEast(mouseEvent, wt);
-                    break;
-                case SE:
-                    resizeSouth(mouseEvent, wt);
-                    resizeEast(mouseEvent, wt);
-                    break;
-                case S:
-                    resizeSouth(mouseEvent, wt);
-                    break;
-                case SW:
-                    resizeSouth(mouseEvent, wt);
-                    resizeWest(mouseEvent, wt);
-                    break;
-                case W:
-                    // TODO update offset West left side accuracy
-                    resizeWest(mouseEvent, wt);
-                    break;
-                default:
-                    break;
-            }
-
-        });
+//
+////        resizePaneTracker.setOnMouseDragged((mouseEvent, wt) -> {
+//            RESIZE_DIRECTION direction = wt.currentResizeDirection.get();
+//
+//            switch (direction) {
+//                case NW:
+//                    // TODO Northwest or Upper Left accuracy
+//                    resizeNorth(mouseEvent, wt);
+//                    resizeWest(mouseEvent, wt);
+//                    break;
+//                case N:
+//                    resizeNorth(mouseEvent, wt);
+//                    break;
+//                case NE:
+//                    //TODO Northeast Upper right corner accuracy
+//                    resizeNorth(mouseEvent, wt);
+//                    resizeEast(mouseEvent, wt);
+//                    break;
+//                case E:
+//                    resizeEast(mouseEvent, wt);
+//                    break;
+//                case SE:
+//                    resizeSouth(mouseEvent, wt);
+//                    resizeEast(mouseEvent, wt);
+//                    break;
+//                case S:
+//                    resizeSouth(mouseEvent, wt);
+//                    break;
+//                case SW:
+//                    resizeSouth(mouseEvent, wt);
+//                    resizeWest(mouseEvent, wt);
+//                    break;
+//                case W:
+//                    // TODO update offset West left side accuracy
+//                    resizeWest(mouseEvent, wt);
+//                    break;
+//                default:
+//                    break;
+//            }
+//
+//        });
 
         // Mouse cursor touching segments
         segmentSelected.addListener( (ob, oldv, newv) -> {


### PR DESCRIPTION
The resize tracker code is now commented out. This will be reworked. Remnants of the old code was attached to the scene and content, that's why it was jumping and messing with press release values.