### PR TITLE
Covalence fix resize issue

### DIFF
--- a/litfx-controls/src/main/java/lit/litfx/controls/covalent/CursorMappings.java
+++ b/litfx-controls/src/main/java/lit/litfx/controls/covalent/CursorMappings.java
@@ -5,11 +5,10 @@
  */
 package lit.litfx.controls.covalent;
 
+import javafx.scene.Cursor;
+
 import java.util.HashMap;
 import java.util.Map;
-import javafx.beans.property.IntegerProperty;
-import javafx.beans.property.SimpleIntegerProperty;
-import javafx.scene.Cursor;
 
 /**
  *
@@ -33,22 +32,9 @@ public enum CursorMappings {
         cursorMap.put(RESIZE_DIRECTION.S, Cursor.S_RESIZE);
         cursorMap.put(RESIZE_DIRECTION.SW, Cursor.SW_RESIZE);
         cursorMap.put(RESIZE_DIRECTION.W, Cursor.W_RESIZE);
-    }    
-    public static RESIZE_DIRECTION[] cursorSegmentArray = new RESIZE_DIRECTION[14];
-    static {
-        cursorSegmentArray[0] = RESIZE_DIRECTION.N;
-        cursorSegmentArray[1] = RESIZE_DIRECTION.NE;
-        cursorSegmentArray[2] = RESIZE_DIRECTION.E;
-        cursorSegmentArray[3] = RESIZE_DIRECTION.SE;
-        cursorSegmentArray[4] = RESIZE_DIRECTION.S;
-        cursorSegmentArray[5] = RESIZE_DIRECTION.S;
-        cursorSegmentArray[6] = RESIZE_DIRECTION.S;
-        cursorSegmentArray[7] = RESIZE_DIRECTION.SW;
-        cursorSegmentArray[8] = RESIZE_DIRECTION.W;
-        cursorSegmentArray[9] = RESIZE_DIRECTION.W;
-        cursorSegmentArray[10] = RESIZE_DIRECTION.W;
-        cursorSegmentArray[11] = RESIZE_DIRECTION.NW;
-        cursorSegmentArray[12] = RESIZE_DIRECTION.NW;
-        cursorSegmentArray[13] = RESIZE_DIRECTION.NW;
-    }    
+    }
+
+    public static Cursor findCursorType(RESIZE_DIRECTION direction) {
+        return cursorMap.get(direction);
+    }
 }

--- a/litfx-controls/src/main/java/lit/litfx/controls/covalent/PathPane.java
+++ b/litfx-controls/src/main/java/lit/litfx/controls/covalent/PathPane.java
@@ -75,19 +75,19 @@ public class PathPane extends AnchorPane {
         outerFrame = createFramePath(this);
         outerFrame.getStyleClass().add("outer-path-frame");
 
-        scene.setOnMouseMoved(me -> {
-            // update segment listener (s0 s2, s2, none...)
-            // when segment listener's invalidation occurs fire cursor to change.
-            logLineSegment(me.getSceneX(), me.getSceneY());
-            outerFrame.toBack();
-//            System.out.println("scene mouse moved");
-        });
-
-        // reset cursor
-        scene.setOnMouseExited( mouseEvent -> {
-            segmentSelected.set(-1);
-            System.out.println("mouse exited group");
-        });
+//        scene.setOnMouseMoved(me -> {
+//            // update segment listener (s0 s2, s2, none...)
+//            // when segment listener's invalidation occurs fire cursor to change.
+//            logLineSegment(me.getSceneX(), me.getSceneY());
+//            outerFrame.toBack();
+////            System.out.println("scene mouse moved");
+//        });
+//
+//        // reset cursor
+//        scene.setOnMouseExited( mouseEvent -> {
+//            segmentSelected.set(-1);
+//            System.out.println("mouse exited group");
+//        });
 
         // createWindowButtons this is the title area and three buttons on top left.
         windowButtons = createWindowButtons(this);
@@ -122,8 +122,8 @@ public class PathPane extends AnchorPane {
         //Disable interactions with the content while minimized.
         contentPane.mouseTransparentProperty().bind(minimizedProperty);
         
-        getChildren().addAll(windowButtons, mainTitleArea,
-            leftAccent, leftTab, outerFrame, mainContentBorderFrame);
+        getChildren().addAll(outerFrame, windowButtons, mainTitleArea,
+            leftAccent, leftTab,  mainContentBorderFrame);
         enterScene = createEnterAnimation(
                 this.contentPane,
                 windowButtons,
@@ -194,6 +194,7 @@ public class PathPane extends AnchorPane {
             (CovalentPaneEvent t) -> {
                 previousLocation = new Point2D(getTranslateX(),getTranslateY());
             });
+
 
         wireListeners();
     }
@@ -579,73 +580,75 @@ public class PathPane extends AnchorPane {
     }
 
     private void wireListeners() {
-        resizePaneTracker = new ResizePaneTracker(contentPane);
 
-        resizePaneTracker.setOnMousePressed((mouseEvent, wt) -> {
-            // store anchor x,y of the stage
-            wt.anchorStageXYCoordValue.set(new Point2D(getTranslateX(), getTranslateY()));
-
-            // TODO Revisit code b/c this might be doing the same thing as line above.
-            wt.paneXCoordValue.set(getTranslateX());
-            wt.paneYCoordValue.set(getTranslateY());
-
-            // anchor of the mouse screen x,y position.
-            wt.anchorCoordValue.set(new Point2D(mouseEvent.getScreenX(), mouseEvent.getScreenY()));
-
-            // current width and height
-            wt.anchorWidthSizeValue.set(contentPane.getWidth());
-            wt.anchorHeightSizeValue.set(contentPane.getHeight());
-            System.out.println("press mouseX = " + mouseEvent.getX() + " translateX = " + getTranslateX());
-
-            // current resize direction
-            wt.currentResizeDirection.set(getCurrentResizeDirection());
-
-            // current line segment
-            wt.currentSegmentIndex.set(segmentSelected.get());
-        });
-
-        resizePaneTracker.setOnMouseDragged((mouseEvent, wt) -> {
-
+// // Rework the resize pane tracker work...
+//        resizePaneTracker = new ResizePaneTracker(contentPane);
+//
+//        resizePaneTracker.setOnMousePressed((mouseEvent, wt) -> {
+//            // store anchor x,y of the stage
+//            wt.anchorStageXYCoordValue.set(new Point2D(getTranslateX(), getTranslateY()));
+//
+//            // TODO Revisit code b/c this might be doing the same thing as line above.
+//            wt.paneXCoordValue.set(getTranslateX());
+//            wt.paneYCoordValue.set(getTranslateY());
+//
+//            // anchor of the mouse screen x,y position.
+//            wt.anchorCoordValue.set(new Point2D(mouseEvent.getScreenX(), mouseEvent.getScreenY()));
+//
+//            // current width and height
+//            wt.anchorWidthSizeValue.set(contentPane.getWidth());
+//            wt.anchorHeightSizeValue.set(contentPane.getHeight());
+//            System.out.println("press mouseX = " + mouseEvent.getX() + " translateX = " + getTranslateX());
+//
+//            // current resize direction
+//            wt.currentResizeDirection.set(getCurrentResizeDirection());
+//
+//            // current line segment
+//            wt.currentSegmentIndex.set(segmentSelected.get());
+//        });
+//
 //        resizePaneTracker.setOnMouseDragged((mouseEvent, wt) -> {
-            RESIZE_DIRECTION direction = wt.currentResizeDirection.get();
-
-            switch (direction) {
-                case NW:
-                    // TODO Northwest or Upper Left accuracy
-                    resizeNorth(mouseEvent, wt);
-                    resizeWest(mouseEvent, wt);
-                    break;
-                case N:
-                    resizeNorth(mouseEvent, wt);
-                    break;
-                case NE:
-                    //TODO Northeast Upper right corner accuracy
-                    resizeNorth(mouseEvent, wt);
-                    resizeEast(mouseEvent, wt);
-                    break;
-                case E:
-                    resizeEast(mouseEvent, wt);
-                    break;
-                case SE:
-                    resizeSouth(mouseEvent, wt);
-                    resizeEast(mouseEvent, wt);
-                    break;
-                case S:
-                    resizeSouth(mouseEvent, wt);
-                    break;
-                case SW:
-                    resizeSouth(mouseEvent, wt);
-                    resizeWest(mouseEvent, wt);
-                    break;
-                case W:
-                    // TODO update offset West left side accuracy
-                    resizeWest(mouseEvent, wt);
-                    break;
-                default:
-                    break;
-            }
-
-        });
+//
+////        resizePaneTracker.setOnMouseDragged((mouseEvent, wt) -> {
+//            RESIZE_DIRECTION direction = wt.currentResizeDirection.get();
+//
+//            switch (direction) {
+//                case NW:
+//                    // TODO Northwest or Upper Left accuracy
+//                    resizeNorth(mouseEvent, wt);
+//                    resizeWest(mouseEvent, wt);
+//                    break;
+//                case N:
+//                    resizeNorth(mouseEvent, wt);
+//                    break;
+//                case NE:
+//                    //TODO Northeast Upper right corner accuracy
+//                    resizeNorth(mouseEvent, wt);
+//                    resizeEast(mouseEvent, wt);
+//                    break;
+//                case E:
+//                    resizeEast(mouseEvent, wt);
+//                    break;
+//                case SE:
+//                    resizeSouth(mouseEvent, wt);
+//                    resizeEast(mouseEvent, wt);
+//                    break;
+//                case S:
+//                    resizeSouth(mouseEvent, wt);
+//                    break;
+//                case SW:
+//                    resizeSouth(mouseEvent, wt);
+//                    resizeWest(mouseEvent, wt);
+//                    break;
+//                case W:
+//                    // TODO update offset West left side accuracy
+//                    resizeWest(mouseEvent, wt);
+//                    break;
+//                default:
+//                    break;
+//            }
+//
+//        });
 
         // Mouse cursor touching segments
         segmentSelected.addListener( (ob, oldv, newv) -> {

--- a/litfx-controls/src/main/java/lit/litfx/controls/covalent/PathPane.java
+++ b/litfx-controls/src/main/java/lit/litfx/controls/covalent/PathPane.java
@@ -103,9 +103,6 @@ public class PathPane extends AnchorPane {
         anchorPt = new Point2D(0,0);
         previousLocation = new Point2D(0,0);
 
-        // resizing uses resizeAnchorPt and resizePreviousLocation
-        //setupResizePaneSupport(desktopPane);
-
         // createLeftAccent
         leftAccent = createLeftAccent(this);
         setupMovePaneSupport(leftAccent);
@@ -142,38 +139,7 @@ public class PathPane extends AnchorPane {
                 outerFrame,
                 mainContentBorderFrame.getMainContentInnerPath());
         
-        // starting initial anchor point
-//        setOnMousePressed(mouseEvent -> {
-//            int segment = resizePaneTracker.currentSegmentIndex.get();
-//            if (segment == -1) {
-//                anchorPt = new Point2D(mouseEvent.getX(), mouseEvent.getY());
-//            }
-//            System.out.println("press root sees segment " + segmentSelected.get());
-//
-//        });
-        // Dragging the stage by moving its xTo,yTo
-        // based on the previous location.
-//        root.setOnMouseDragged(mouseEvent -> {
-//            System.out.println("drag root sees segment " + resizeWindowTracker.currentSegmentIndex.get());
-//            int segment = resizeWindowTracker.currentSegmentIndex.get();
-//            if (segment == -1 && anchorPt != null && previousLocation != null) {
-//                stage.setX(previousLocation.getX()
-//                        + mouseEvent.getScreenX()
-//                        - anchorPt.getX());
-//                stage.setY(previousLocation.getY()
-//                        + mouseEvent.getScreenY()
-//                        - anchorPt.getY());
-//            }
-//        });
 
-        // Set the new previous to the current mouse xTo,yTo coordinate
-//        scene.setOnMouseReleased(mouseEvent -> {
-//            int segment = resizePaneTracker.currentSegmentIndex.get();
-//            //if (segment == -1) {
-//                previousLocation = new Point2D(getTranslateX(),getTranslateY());
-//            //}
-//            System.out.println("released");
-//        });
         //if the pane is minimized, double click to bring it back
         addEventHandler(MouseEvent.MOUSE_CLICKED, e -> {
             if(minimizedProperty.get() && 
@@ -207,29 +173,6 @@ public class PathPane extends AnchorPane {
         wireListeners();
     }
 
-
-
-//    private void handleMousePressed(MouseEvent mouseEvent) {
-//        int segment = resizePaneTracker.currentSegmentIndex.get();
-//        if (segment == -1) {
-//            anchorPt = new Point2D(mouseEvent.getScreenX(), mouseEvent.getScreenY());
-//        }
-//        System.out.println("press root sees segment " + resizePaneTracker.currentSegmentIndex.get());
-//    }
-
-    /**
-     * Resizing window mouse pressed.
-     * @param mouseEvent
-     */
-    private void handleResizeWindowMousePressed(MouseEvent mouseEvent) {
-        int segmentNum = segmentSelected.get();
-        if (segmentNum == -1) {
-            anchorPt = new Point2D(mouseEvent.getX(), mouseEvent.getY());
-            mouseEvent.consume();
-        }
-        System.out.println("press root sees segment num=" + segmentNum + " resizeAnchorPt=" + anchorPt);
-    }
-
     /**
      * Position window mouse pressed
      * @param mouseEvent
@@ -252,24 +195,6 @@ public class PathPane extends AnchorPane {
 //        }
 //    }
 
-    /**
-     * Resizing window mouse dragged
-     * @param mouseEvent
-     */
-    private void handleResizeWindowMouseDragged(MouseEvent mouseEvent) {
-
-        int segmentNum = segmentSelected.get();
-        System.out.println("drag root sees segment " + segmentNum);
-        if (segmentNum == -1 && anchorPt != null && previousLocation != null) {
-            this.setTranslateX(previousLocation.getX()
-                    + mouseEvent.getX()
-                    - anchorPt.getX());
-            this.setTranslateY(previousLocation.getY()
-                    + mouseEvent.getY()
-                    - anchorPt.getY());
-            mouseEvent.consume();
-        }
-    }
 
     /**
      * Position window mouse dragged
@@ -286,15 +211,6 @@ public class PathPane extends AnchorPane {
                     + mouseEvent.getSceneY()
                     - anchorPt.getY());
         }
-    }
-
-    /**
-     * Resizing window mouse release
-     * @param mouseEvent
-     */
-    private void handleResizeWindowMouseReleased(MouseEvent mouseEvent) {
-        previousLocation = new Point2D(getTranslateX(),getTranslateY());
-        System.out.println("released previousLocation: "+ previousLocation);
     }
 
     /**
@@ -319,15 +235,6 @@ public class PathPane extends AnchorPane {
         node.addEventHandler(MouseEvent.MOUSE_RELEASED, this::handlePositionWindowMouseReleased);
     }
 
-    /**
-     * Not Called experimental
-     * @param node
-     */
-    private void setupResizePaneSupport(Node node){
-        node.addEventFilter(MouseEvent.MOUSE_PRESSED, this::handleResizeWindowMousePressed);
-        node.addEventFilter(MouseEvent.MOUSE_DRAGGED, this::handleResizeWindowMouseDragged);
-        node.addEventFilter(MouseEvent.MOUSE_RELEASED, this::handleResizeWindowMouseReleased);
-    }
     private Animation createEnterBorderAnimation(Path borderFrame, double totalMS) {
         double totalLength = Utils.getTotalLength(borderFrame);
         borderFrame.getStrokeDashArray().add(totalLength);
@@ -685,7 +592,6 @@ public class PathPane extends AnchorPane {
 
         resizePaneTracker.setOnMouseDragged((mouseEvent, wt) -> {
 
-//        resizePaneTracker.setOnMouseDragged((mouseEvent, wt) -> {
             RESIZE_DIRECTION direction = wt.currentResizeDirection.get();
 
             switch (direction) {
@@ -902,39 +808,6 @@ public class PathPane extends AnchorPane {
         cursorSegmentArray[13] = RESIZE_DIRECTION.NW;
 
         return newFrame;
-    }
-
-    public Cursor findResizeCursor(double mouseSceneX, double mouseSceneY, double threshold) {
-        //System.out.println(lineSegmentMap);
-        // biggerShape = clone current path
-        // find centroid as pivotX, pivotY
-        // create a Scale add as transform
-        // Shape hoverArea = Path.subtract(biggerShape, outerFrame)
-        // translate hoverArea as relative to (parentX, parentY)
-        // determine if cursor is inside hoverArea
-
-        //Shape outer
-        Optional<Map.Entry<Integer, Line>> segIndxLineEntryFound = lineSegmentMap
-                .entrySet()
-                .stream()
-                .filter(segIndxLineEntry -> {
-                    Line line = segIndxLineEntry.getValue();
-
-                    return Utils.isPointNearLineLocalToScene(mouseSceneX,
-                            mouseSceneY,
-                            this,
-                            line,
-                            (int) threshold,
-                            segIndxLineEntry.getKey());
-                })
-                .findAny();
-        if (segIndxLineEntryFound.isPresent()) {
-            // Determine the cursor type based on the cursorSegmentArray.
-            // Map.Entry<Integer, Line> segment index as Integer and Line object.
-            return CursorMappings.findCursorType(cursorSegmentArray[segIndxLineEntryFound.get().getKey()]);
-        }
-
-        return Cursor.DEFAULT;
     }
 }
 

--- a/litfx-controls/src/main/java/lit/litfx/controls/covalent/PathWindow.java
+++ b/litfx-controls/src/main/java/lit/litfx/controls/covalent/PathWindow.java
@@ -1,17 +1,6 @@
 package lit.litfx.controls.covalent;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import javafx.animation.Animation;
-import javafx.animation.FadeTransition;
-import javafx.animation.KeyFrame;
-import javafx.animation.KeyValue;
-import javafx.animation.ParallelTransition;
-import javafx.animation.SequentialTransition;
-import javafx.animation.Timeline;
+import javafx.animation.*;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.geometry.Point2D;
@@ -31,15 +20,13 @@ import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
 import javafx.util.Duration;
-import static lit.litfx.controls.covalent.BindablePointBuilder.bindXToPrevX;
-import static lit.litfx.controls.covalent.BindablePointBuilder.bindXToWidth;
-import static lit.litfx.controls.covalent.BindablePointBuilder.bindYToHeight;
-import static lit.litfx.controls.covalent.BindablePointBuilder.xTo;
-import static lit.litfx.controls.covalent.BindablePointBuilder.yTo;
 import lit.litfx.controls.covalent.CursorMappings.RESIZE_DIRECTION;
+
+import java.util.*;
+
+import static lit.litfx.controls.covalent.BindablePointBuilder.*;
 import static lit.litfx.controls.covalent.CursorMappings.RESIZE_DIRECTION.NONE;
 import static lit.litfx.controls.covalent.CursorMappings.cursorMap;
-import static lit.litfx.controls.covalent.CursorMappings.cursorSegmentArray;
 
 /*
  notes: https://stackoverflow.com/questions/47213156/how-to-get-length-of-path
@@ -62,7 +49,7 @@ public class PathWindow {
 //        cursorMap.put(RESIZE_DIRECTION.SW, Cursor.SW_RESIZE);
 //        cursorMap.put(RESIZE_DIRECTION.W, Cursor.W_RESIZE);
 //    }
-//    private static RESIZE_DIRECTION[] cursorSegmentArray = new RESIZE_DIRECTION[14];
+    private RESIZE_DIRECTION[] cursorSegmentArray = new RESIZE_DIRECTION[14];
     private IntegerProperty segmentSelected = new SimpleIntegerProperty(-1);
 //    static {
 //        cursorSegmentArray[0] = RESIZE_DIRECTION.N;
@@ -766,6 +753,21 @@ public class PathWindow {
                 .closeSeg()
                 .build();
 
+        // Assign mouse cursor direction for each segment.
+        cursorSegmentArray[0] = RESIZE_DIRECTION.N;
+        cursorSegmentArray[1] = RESIZE_DIRECTION.NE;
+        cursorSegmentArray[2] = RESIZE_DIRECTION.E;
+        cursorSegmentArray[3] = RESIZE_DIRECTION.SE;
+        cursorSegmentArray[4] = RESIZE_DIRECTION.S;
+        cursorSegmentArray[5] = RESIZE_DIRECTION.S;
+        cursorSegmentArray[6] = RESIZE_DIRECTION.S;
+        cursorSegmentArray[7] = RESIZE_DIRECTION.SW;
+        cursorSegmentArray[8] = RESIZE_DIRECTION.W;
+        cursorSegmentArray[9] = RESIZE_DIRECTION.W;
+        cursorSegmentArray[10] = RESIZE_DIRECTION.W;
+        cursorSegmentArray[11] = RESIZE_DIRECTION.NW;
+        cursorSegmentArray[12] = RESIZE_DIRECTION.NW;
+        cursorSegmentArray[13] = RESIZE_DIRECTION.NW;
         return outerFrame;
     }
 }

--- a/litfx-controls/src/main/java/lit/litfx/controls/covalent/Utils.java
+++ b/litfx-controls/src/main/java/lit/litfx/controls/covalent/Utils.java
@@ -213,13 +213,38 @@ public class Utils {
 
 
 
-    public static boolean isPointNearLine(double targetX, double targetY, Line line, int threshold, Integer segment) {
+    public static boolean isPointNearLine(double targetX,
+                                          double targetY,
+                                          Line line,
+                                          int threshold,
+                                          Integer segment) {
         //take the distance from point 1 to the target, and point 2 to the target,
         double distance = distToSegment(targetX, targetY,
                 line.getStartX(), line.getStartY(),
                 line.getEndX(), line.getEndY());
         boolean isNear = equals(distance, 0 ) || (greaterThan(distance, 0) && lessThan(distance, threshold));
         if (isNear) System.out.printf("isNear:" + isNear + " segment: %d, cursor(%f,%f), nearDistance = %s, %s \n",
+                segment, targetX, targetY, distance, line.toString());
+        return isNear;
+    }
+
+    public static boolean isPointNearLineLocalToScene(double targetX,
+                                          double targetY,
+                                          PathPane pathPane,
+                                          Line line,
+                                          int threshold,
+                                          Integer segment) {
+
+        Point2D startPoint = line.localToScene(line.getStartX(),line.getStartY());
+        Point2D endPoint = line.localToScene(line.getEndX(),line.getEndY());
+        Point2D mousePt = new Point2D(targetX, targetY);
+        System.out.println("mousePt" + mousePt + " was " + targetX + ", " + targetY);
+        //take the distance from point 1 to the target, and point 2 to the target,
+        double distance = distToSegment(targetX, targetY,
+                startPoint.getX(), startPoint.getY(),
+                endPoint.getX(), endPoint.getY());
+        boolean isNear = equals(distance, 0 ) || (greaterThan(distance, 0) && lessThan(distance, threshold));
+        if (isNear) System.out.printf("isPointNearLineLocalToParent() isNear:" + isNear + " segment: %d, cursor(%f,%f), nearDistance = %s, %s \n",
                 segment, targetX, targetY, distance, line.toString());
         return isNear;
     }

--- a/litfx-demos/src/main/java/lit/litfx/demos/CovalentPaneDemo.java
+++ b/litfx-demos/src/main/java/lit/litfx/demos/CovalentPaneDemo.java
@@ -91,6 +91,7 @@ public class CovalentPaneDemo extends Application {
                     new BackgroundFill(Color.TRANSPARENT, CornerRadii.EMPTY, Insets.EMPTY)));
 
             PathPane newPane = new PathPane(scene,
+                    desktopPane,
                     640, 480,
                     someContentPane,
                     "Cyber Battlespace", "Notifications",
@@ -111,6 +112,46 @@ public class CovalentPaneDemo extends Application {
         scene.getStylesheets().add(CSS);
         CSS = this.getClass().getResource("covalent.css").toExternalForm();
         scene.getStylesheets().add(CSS);
+
+//        // change cursor when
+//        ObjectProperty<Cursor> cursorState = new SimpleObjectProperty<>();
+//        cursorState.addListener( (ob, oldv, nv) -> {
+//            Cursor cursor = nv;
+//            //if (!oldv.equals(nv)) {
+//                scene.setCursor(nv);
+//            //}
+//        });
+//
+//        // intercept mouse hover to determine which cursor to display
+//        scene.addEventFilter(MouseEvent.MOUSE_MOVED, mouseEvent -> {
+//            System.out.println(":-) mouse cursor " + mouseEvent.getX() + ", " + mouseEvent.getY() + " " + mouseEvent.getSource().getClass());
+//
+//            // Changing cursor when mouse pointer is outside bounding panes.
+//            // is pt near any bounding edge?
+//            double bufferRegion = 4; // a buffer region around bounding box
+//            double x = mouseEvent.getSceneX();
+//            double y = mouseEvent.getSceneY();
+//            desktopPane
+//                    .getChildren()
+//                    .stream()
+//                    .filter( node -> node instanceof PathPane)
+//                    .findAny()
+//                    .map(node -> (PathPane) node)
+//                    .ifPresentOrElse( pathPane -> {
+//
+//                        // determine window edges
+//                        // n,ne,e, se, s, sw, w, nw.
+//
+//                        // withing buffer area outside of bounding box.
+//                        Cursor c = pathPane.findResizeCursor(x, y, bufferRegion);
+//                        scene.setCursor(c);
+//
+//                    },
+//                       // else set to default cursor
+//                       () -> scene.setCursor(Cursor.DEFAULT)
+//                    );
+//        });
+
 
         // fun matrix effect
         // On MacOS use ⌘ + N

--- a/litfx-demos/src/main/java/lit/litfx/demos/CovalentPaneDemo.java
+++ b/litfx-demos/src/main/java/lit/litfx/demos/CovalentPaneDemo.java
@@ -113,45 +113,6 @@ public class CovalentPaneDemo extends Application {
         CSS = this.getClass().getResource("covalent.css").toExternalForm();
         scene.getStylesheets().add(CSS);
 
-//        // change cursor when
-//        ObjectProperty<Cursor> cursorState = new SimpleObjectProperty<>();
-//        cursorState.addListener( (ob, oldv, nv) -> {
-//            Cursor cursor = nv;
-//            //if (!oldv.equals(nv)) {
-//                scene.setCursor(nv);
-//            //}
-//        });
-//
-//        // intercept mouse hover to determine which cursor to display
-//        scene.addEventFilter(MouseEvent.MOUSE_MOVED, mouseEvent -> {
-//            System.out.println(":-) mouse cursor " + mouseEvent.getX() + ", " + mouseEvent.getY() + " " + mouseEvent.getSource().getClass());
-//
-//            // Changing cursor when mouse pointer is outside bounding panes.
-//            // is pt near any bounding edge?
-//            double bufferRegion = 4; // a buffer region around bounding box
-//            double x = mouseEvent.getSceneX();
-//            double y = mouseEvent.getSceneY();
-//            desktopPane
-//                    .getChildren()
-//                    .stream()
-//                    .filter( node -> node instanceof PathPane)
-//                    .findAny()
-//                    .map(node -> (PathPane) node)
-//                    .ifPresentOrElse( pathPane -> {
-//
-//                        // determine window edges
-//                        // n,ne,e, se, s, sw, w, nw.
-//
-//                        // withing buffer area outside of bounding box.
-//                        Cursor c = pathPane.findResizeCursor(x, y, bufferRegion);
-//                        scene.setCursor(c);
-//
-//                    },
-//                       // else set to default cursor
-//                       () -> scene.setCursor(Cursor.DEFAULT)
-//                    );
-//        });
-
 
         // fun matrix effect
         // On MacOS use ⌘ + N


### PR DESCRIPTION
Resizing of the PathPane works successfully with the following mouse cursor directions: east, south-east, south

To reproduce: hover mouse cursor on the outerframe of the window.

**Outstanding issues**: The resizing of the following directions aren't working correctly: south-west, west, north-west, north, north-east.

The width and height tends to jump around (not accurate). This might be because of mouse events x,y may need to be translated to the parent's coordinates.

You may or may not want to merge yet, but this PR, will help us see a diffs.